### PR TITLE
Add Router setup with placeholder pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1613,6 +1614,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2484,6 +2494,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2549,6 +2597,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,28 @@
-
-
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import HomePage from "./pages/HomePage.jsx";
+import JourneyPage from './pages/JourneyPage.jsx';
+import MyProgress from './pages/MyProgress.jsx';
+import ProfilePage from './pages/ProfilePage.jsx';
+import RegisterForm from './Auth/RegisterForm.jsx';
+import LoginForm from './Auth/LoginForm.jsx';
+import Logout from './Auth/Logout.jsx';
+import ResetPassword from './Auth/ResetPassword.jsx';
 
 function App() {
   return (
-    <div>
-      <h1>Welcome to Skill Forge</h1>
-      <p>Your journey to mastering skills starts here!</p>
-    </div>
-  );  
+    <Router>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/journey" element={<JourneyPage />} />
+        <Route path="/progress" element={<MyProgress />} />
+        <Route path="/profile" element={<ProfilePage />} />
+        <Route path='/register' element={<RegisterForm />} />
+        <Route path='/login' element={<LoginForm />} />
+        <Route path='/logout' element={<Logout />} />
+        <Route path='/reset' element={<ResetPassword />} />
+      </Routes>
+    </Router>
+  )
 }
 
 export default App;

--- a/src/Auth/LoginForm.jsx
+++ b/src/Auth/LoginForm.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const LoginForm = () => (
+  <div>
+    <h1>Login</h1>
+  </div>
+);
+
+export default LoginForm;

--- a/src/Auth/Logout.jsx
+++ b/src/Auth/Logout.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Logout = () => (
+  <div>
+    <h1>Logout</h1>
+  </div>
+);
+
+export default Logout;

--- a/src/Auth/RegisterForm.jsx
+++ b/src/Auth/RegisterForm.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const RegisterForm = () => (
+  <div>
+    <h1>Register</h1>
+  </div>
+);
+
+export default RegisterForm;

--- a/src/Auth/ResetPassword.jsx
+++ b/src/Auth/ResetPassword.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const ResetPassword = () => (
+  <div>
+    <h1>Reset Password</h1>
+  </div>
+);
+
+export default ResetPassword;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const HomePage = () => (
+  <div>
+    <h1>Home Page</h1>
+  </div>
+);
+
+export default HomePage;

--- a/src/pages/JourneyPage.jsx
+++ b/src/pages/JourneyPage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const JourneyPage = () => (
+  <div>
+    <h1>Journey Page</h1>
+  </div>
+);
+
+export default JourneyPage;

--- a/src/pages/MyProgress.jsx
+++ b/src/pages/MyProgress.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const MyProgress = () => (
+  <div>
+    <h1>My Progress</h1>
+  </div>
+);
+
+export default MyProgress;

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const ProfilePage = () => (
+  <div>
+    <h1>Profile Page</h1>
+  </div>
+);
+
+export default ProfilePage;


### PR DESCRIPTION
## Summary
- add react-router-dom dependency
- create placeholder Auth and pages components
- configure App.jsx with routing to new pages

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68622dc26bf8832983279be290cac008